### PR TITLE
fix: Cannot read property 'nextSibling' of null

### DIFF
--- a/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
+++ b/modules/tinymce/src/plugins/lists/main/ts/core/Delete.ts
@@ -225,7 +225,9 @@ const backspaceDeleteIntoListCaret = (editor: Editor, isForward: boolean): boole
 
       editor.undoManager.transact(() => {
         removeBlock(dom, block, root);
-        ToggleList.mergeWithAdjacentLists(dom, otherLi.parentNode as HTMLElement);
+        if (otherLi.parentNode) {
+          ToggleList.mergeWithAdjacentLists(dom, otherLi.parentNode as HTMLElement);
+        }
         editor.selection.select(otherLi, true);
         editor.selection.collapse(isForward);
       });


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Fixes exception sometimes encountered when contents of lists. See linked GH issue for exact repro steps.

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable): https://github.com/tinymce/tinymce/issues/6383
